### PR TITLE
Fix: link Twitter Cherry

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -74,4 +74,5 @@ Todos são bem-vindos a contribuir com este repositório. Para fazer isso, basta
 Para qualquer sugestão ou ajuda entre em contato com nossos representantes.
 
 **Samuel Rodrigues** - [Twitter](https://twitter.com/samucadev)
-**Cherry** - [Twitter](https://twitter.com/samucadev)
+
+**Cherry** - [Twitter](https://twitter.com/cherry_ramatis)


### PR DESCRIPTION
O link do Twitter da Cherry era o mesmo do Samuca, mudei o link para o certo e dei um espaço para melhorar a visualização.